### PR TITLE
Loader: from a queue to a DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ classDiagram
 classDiagram
     class Consumer
     <<interface>> Consumer
-    Consumer <|.. rabbitMQConsumer
-    class rabbitMQConsumer{
+    Consumer <|.. RabbitMQConsumer
+    class RabbitMQConsumer{
         +consume()
     }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In the here presented implementation:
 sends it back to the broker.
 * A consumer `Loader` store the structured data into a DB.
 ```mermaid
-flowchart TD
+flowchart LR
   subgraph Sources
   sourceHTTP@{ shape: lean-r, label: "source HTTP" }
   sourceWS@{ shape: lean-r, label: "source WS" }
@@ -39,19 +39,22 @@ flowchart TD
   broker --> q5@{ shape: das, label: "source.ws.structured_data" }
   broker --> q4@{ shape: das, label: "transformed.avg" }
 
-  q1 & q2 & q4 & q5 --> QueueLogger@{ shape: lin-rect, label: "Queue Logger" }
+  q1 & q2 & q4 --> QueueLogger@{ shape: lin-rect, label: "Queue Logger" }
   q3 --> Transformer@{ shape: lin-rect, label: "Transformer" }
   Transformer -- transformed.avg transformed.std --> broker
   q5 --> Loader@{ shape: lin-rect, label: "Loader" }
   end
 
+  subgraph Persistence
   Loader --> DB@{ shape: db, label: "DB" }
+  end
+  
   QueueLogger --> log@{ shape: rect, label: "container's logs:
   WS data 0
   WS data 1
   HTTP data 0
   AVG data 0
-  WS struct. data 0
+  WS data 2
   ..." }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,43 +7,51 @@ and pushes it to a message passing `Broker` facility. One or more `Consumer`s
 access the data to operate on it.
 
 In the here presented implementation:
-* Endpoint `/ws` produces a list of Normally distributed floats.
-* Endpoint `/http` produces a scalar character uniformely distributed.
+* The endpoint `/ws` produces a list of Normally distributed floats.
+* The endpoint `/ws/structured_data` produces random values based on a SQL model as defined in `src/models`.
+* The endpoint `/http` produces a scalar character uniformely distributed.
 * The `Broker` is an instance of RabbitMQ.
 * A consumer `Queue Logger` retrieves data from the broker and logs it.
 * A consumer `Transformer` evaluates some statistics on some of the data, and
 sends it back to the broker.
+* A consumer `Loader` store the structured data into a DB.
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Sources
   sourceHTTP@{ shape: lean-r, label: "source HTTP" }
   sourceWS@{ shape: lean-r, label: "source WS" }
   end
 
   subgraph **Pastiposte**
-  listenerHTTP@{ shape: lin-rect, label: "Listener HTTP" }
-  listenerWS@{ shape: lin-rect, label: "Listener WS" }
+  listenerHTTP@{ shape: lin-rect, label: "Listener /http" }
+  listenerWS@{ shape: lin-rect, label: "Listener /ws" }
+  listenerWSStruct@{ shape: lin-rect, label: "Listener /ws/structured_data" }
   listenerHTTP -->  sourceHTTP
   listenerWS <--> sourceWS
+  listenerWSStruct <--> sourceWS
   listenerHTTP -- source.http --> broker@{ shape: hex, label: "Broker" }
   listenerWS -- source.ws --> broker@{ shape: hex, label: "Broker" }
+  listenerWSStruct -- source.ws.structured_data --> broker@{ shape: hex, label: "Broker" }
 
   broker --> q1@{ shape: das, label: "source.ws" }
   broker --> q2@{ shape: das, label: "source.http" }
   broker --> q3@{ shape: das, label: "source.ws" }
+  broker --> q5@{ shape: das, label: "source.ws.structured_data" }
   broker --> q4@{ shape: das, label: "transformed.avg" }
 
-  q1 & q2 & q4 --> QueueLogger@{ shape: lin-rect, label: "Queue Logger"}
-  q3 --> Transformer@{ shape: lin-rect, label: "Transformer"}
+  q1 & q2 & q4 & q5 --> QueueLogger@{ shape: lin-rect, label: "Queue Logger" }
+  q3 --> Transformer@{ shape: lin-rect, label: "Transformer" }
   Transformer -- transformed.avg transformed.std --> broker
+  q5 --> Loader@{ shape: lin-rect, label: "Loader" }
   end
 
+  Loader --> DB@{ shape: db, label: "DB" }
   QueueLogger --> log@{ shape: rect, label: "container's logs:
   WS data 0
   WS data 1
   HTTP data 0
   AVG data 0
-  WS data 2
+  WS struct. data 0
   ..." }
 ```
 

--- a/build/loader/Dockerfile
+++ b/build/loader/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+COPY build/loader/requirements.txt /
+RUN pip install --no-cache-dir --upgrade -r ./requirements.txt
+
+COPY src/ /app/src
+WORKDIR /app/src
+
+CMD ["python", "-m", "loader.loader"]

--- a/build/loader/requirements.txt
+++ b/build/loader/requirements.txt
@@ -1,0 +1,3 @@
+pika==1.3.2
+SQLAlchemy==2.0.45
+psycopg2-binary==2.9.11

--- a/build/server/requirements.txt
+++ b/build/server/requirements.txt
@@ -4,3 +4,4 @@ requests==2.32.3
 retry==0.9.2
 fastapi==0.115.6
 uvicorn==0.34.0
+SQLAlchemy==2.0.45

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -44,6 +44,29 @@ services:
       server:
         condition: service_healthy
 
+  listener-ws-structured:
+    annotations:
+      description: "websocket connection to source for structured data"
+    build:
+      context: ../
+      dockerfile: build/listener/Dockerfile
+    networks:
+      - local-network
+    environment:
+      URL: "ws://server:12345/ws/structured_data"
+      SLEEP: 0
+      BROKER_BACKEND: "rabbitmq"
+      BROKER_HOST: "rabbitmq"
+      BROKER_EXCHANGE: "exchange"
+      BROKER_EXCHANGE_TYPE: "topic"
+      BROKER_ROUTING_KEY_OUT: "source.ws.structured_data"
+      LOG_LEVEL: "INFO"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+
   listener-http:
     annotations:
       description: "HTTP requests to source"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -104,12 +104,10 @@ services:
       BROKER_HOST: "rabbitmq"
       BROKER_EXCHANGE: "exchange"
       BROKER_EXCHANGE_TYPE: "topic"
-      BROKER_ROUTING_KEY_IN: "source.#, transformed.avg"
+      BROKER_ROUTING_KEY_IN: "source.*, transformed.avg"
       LOG_LEVEL: "INFO"
     depends_on:
       rabbitmq:
-        condition: service_healthy
-      server:
         condition: service_healthy
 
   transformer:
@@ -132,7 +130,26 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
-      server:
+
+  loader:
+    annotations:
+      description: "Store structured data in DB"
+    build:
+      context: ../
+      dockerfile: build/loader/Dockerfile
+    networks:
+      - local-network
+    environment:
+      SLEEP: 0
+      DB_URL: "postgresql://postgres:postgres@postgres-DB:5432/pastiposte"
+      BROKER_BACKEND: "rabbitmq"
+      BROKER_HOST: "rabbitmq"
+      BROKER_EXCHANGE: "exchange"
+      BROKER_EXCHANGE_TYPE: "topic"
+      BROKER_ROUTING_KEY_IN: "source.ws.structured_data"
+      LOG_LEVEL: "INFO"
+    depends_on:
+      rabbitmq:
         condition: service_healthy
 
   rabbitmq:
@@ -145,6 +162,25 @@ services:
       - "35672:5672"
     healthcheck:
       test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      start_period: 20s
+      retries: 3
+
+  postgres-DB:
+    annotations:
+      description: "DBRMS"
+    image: postgres:alpine
+    networks:
+      - local-network
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=pastiposte
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: pg_isready -U postgres
       interval: 30s
       timeout: 30s
       start_period: 20s

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       BROKER_HOST: "rabbitmq"
       BROKER_EXCHANGE: "exchange"
       BROKER_EXCHANGE_TYPE: "topic"
-      BROKER_ROUTING_KEY_IN: "source.*, transformed.avg"
+      BROKER_ROUTING_KEY_IN: "source.#, transformed.avg"
       LOG_LEVEL: "INFO"
     depends_on:
       rabbitmq:

--- a/src/interfaces/consumer.py
+++ b/src/interfaces/consumer.py
@@ -28,7 +28,7 @@ class Consumer(ABC):
         pass
 
 
-class rabbitMQConsumer(Consumer):
+class RabbitMQConsumer(Consumer):
     """
     Interface class for a RabbitMQ dependant consumer
     """

--- a/src/loader/loader.py
+++ b/src/loader/loader.py
@@ -1,0 +1,39 @@
+"""Load to persistence DB"""
+
+from typing import Any, Dict
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from interfaces.message_broker import Broker
+from interfaces.consumer import RabbitMQConsumer
+from commons.configuration import Configuration
+from commons.broker import broker
+from models.sql import StructuredData
+
+
+class Loader(RabbitMQConsumer):
+
+    def init_db_session(self, **kwargs):
+        # for future reference:
+        # you could move these at module's level scope to let more than one
+        # class open sessions on the same engine
+        db_engine = create_engine(self.db_url, **kwargs)
+        self.session_maker = sessionmaker(db_engine)
+
+    def _action(self, message: Dict[str, Any]) -> Any:
+        with self.session_maker() as session:
+            data = message["response"]
+            record = StructuredData(**data)
+            session.add(record)
+            session.commit()
+
+
+def main(broker: Broker) -> None:
+    config = Configuration()
+    loader = Loader(broker, config["sleep"], db_url=config["db_url"])
+    loader.init_db_session()
+    loader.consume()
+
+
+if __name__ == "__main__":
+    main(broker)

--- a/src/loader/loader.py
+++ b/src/loader/loader.py
@@ -1,5 +1,6 @@
 """Load to persistence DB"""
 
+import json
 from typing import Any, Dict
 
 from sqlalchemy import create_engine
@@ -8,19 +9,22 @@ from interfaces.message_broker import Broker
 from interfaces.consumer import RabbitMQConsumer
 from commons.configuration import Configuration
 from commons.broker import broker
+from models import ModelBase
 from models.sql import StructuredData
 
 
 class Loader(RabbitMQConsumer):
 
-    def init_db_session(self, **kwargs):
+    def init_db(self, **kwargs):
         # for future reference:
         # you could move these at module's level scope to let more than one
-        # class open sessions on the same engine
-        db_engine = create_engine(self.db_url, **kwargs)
+        # class create the database and open sessions on the same engine
+        db_engine = create_engine(self.kwargs["db_url"], **kwargs)
+        ModelBase.metadata.create_all(db_engine)  # to remove for DB versioning
         self.session_maker = sessionmaker(db_engine)
 
     def _action(self, message: Dict[str, Any]) -> Any:
+        message = json.loads(message)
         with self.session_maker() as session:
             data = message["response"]
             record = StructuredData(**data)
@@ -31,7 +35,7 @@ class Loader(RabbitMQConsumer):
 def main(broker: Broker) -> None:
     config = Configuration()
     loader = Loader(broker, config["sleep"], db_url=config["db_url"])
-    loader.init_db_session()
+    loader.init_db()
     loader.consume()
 
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,7 @@
+"""Data models"""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class ModelBase(DeclarativeBase):
+    pass

--- a/src/models/sql.py
+++ b/src/models/sql.py
@@ -1,0 +1,14 @@
+"""Data models"""
+
+from models import ModelBase
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class StructuredData(ModelBase):
+    """A model for structured data"""
+
+    __tablename__ = "structured_data"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    col_int: Mapped[int] = mapped_column()
+    col_str: Mapped[str] = mapped_column()
+    col_bool: Mapped[bool] = mapped_column()

--- a/src/queue_logger/queue_logger.py
+++ b/src/queue_logger/queue_logger.py
@@ -1,13 +1,13 @@
 from typing import Any
 
 from interfaces.message_broker import Broker
-from interfaces.consumer import rabbitMQConsumer
+from interfaces.consumer import RabbitMQConsumer
 from commons.logger import logger
 from commons.configuration import Configuration
 from commons.broker import broker
 
 
-class queueLogger(rabbitMQConsumer):
+class QueueLogger(RabbitMQConsumer):
 
     def _action(self, message: Any):
         logger.info(message)
@@ -15,7 +15,7 @@ class queueLogger(rabbitMQConsumer):
 
 def main(broker: Broker) -> None:
     config = Configuration()
-    queue_logger = queueLogger(broker, config["sleep"])
+    queue_logger = QueueLogger(broker, config["sleep"])
     queue_logger.consume()
 
 

--- a/src/server/data_generator.py
+++ b/src/server/data_generator.py
@@ -1,15 +1,36 @@
 import random
 import string
-from typing import Any
+from typing import Any, Dict
+
+TYPE_GENERATORS = {
+    "int": lambda: random.randint(1, 1000),
+    "char": lambda: random.choices(string.ascii_letters, k=1),
+    "str": lambda: "".join(random.choices(string.ascii_letters, k=40)),
+    "float_uni": lambda: random.uniform(0, 1000),
+    "float_normal": lambda: random.gauss(0, 1),
+    "bool": lambda: random.choice([True, False]),
+}
 
 
-def _format(data: Any):
+def _format(data: Any) -> Dict[str, Any]:
     return {"response": data}
 
 
-def gauss_list(size: int, mean: float = 0, std: float = 1):
-    return _format([random.gauss(mean, std) for _ in range(size)])
+def gauss_list(size: int):
+    return _format([TYPE_GENERATORS["float_normal"]() for _ in range(size)])
 
 
 def char_scalar():
-    return _format(random.choice(string.ascii_letters))
+    return _format(TYPE_GENERATORS["char"]())
+
+
+def structured_data():
+    from models.sql import StructuredData
+
+    return _format(
+        {
+            col_name: TYPE_GENERATORS[str(col.type.python_type.__name__)]()
+            for col_name, col in StructuredData.__mapper__.columns.items()
+            if col_name != "id"
+        }
+    )

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -7,7 +7,7 @@ from fastapi.websockets import WebSocketDisconnect
 
 from commons.configuration import Configuration
 from commons.logger import logger
-from server.data_generator import gauss_list, char_scalar
+from server.data_generator import gauss_list, char_scalar, structured_data
 
 app = FastAPI()
 config = Configuration()
@@ -20,6 +20,19 @@ async def ws_endpoint(websocket: WebSocket):
     await websocket.accept()
     while True:
         data = gauss_list(LIST_LEN)
+        logger.debug(data)
+        try:
+            await websocket.send_json(data)
+        except WebSocketDisconnect:
+            break
+        await asyncio.sleep(config["sleep"])
+
+
+@app.websocket("/ws/structured_data")
+async def ws_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    while True:
+        data = structured_data()
         logger.debug(data)
         try:
             await websocket.send_json(data)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -18,27 +18,27 @@ LIST_LEN = 10
 @app.websocket("/ws")
 async def ws_endpoint(websocket: WebSocket):
     await websocket.accept()
-    while True:
-        data = gauss_list(LIST_LEN)
-        logger.debug(data)
-        try:
+    try:
+        while True:
+            data = gauss_list(LIST_LEN)
+            logger.debug(data)
             await websocket.send_json(data)
-        except WebSocketDisconnect:
-            break
-        await asyncio.sleep(config["sleep"])
+            await asyncio.sleep(config["sleep"])
+    except WebSocketDisconnect:
+        logger.info("client disconnected")
 
 
 @app.websocket("/ws/structured_data")
-async def ws_endpoint(websocket: WebSocket):
+async def ws_endpoint_structured_data(websocket: WebSocket):
     await websocket.accept()
-    while True:
-        data = structured_data()
-        logger.debug(data)
-        try:
+    try:
+        while True:
+            data = structured_data()
+            logger.debug(data)
             await websocket.send_json(data)
-        except WebSocketDisconnect:
-            break
-        await asyncio.sleep(config["sleep"])
+            await asyncio.sleep(config["sleep"])
+    except WebSocketDisconnect:
+        logger.info("client disconnected")
 
 
 @app.get("/http", status_code=status.HTTP_200_OK)

--- a/src/transformer/transformer.py
+++ b/src/transformer/transformer.py
@@ -3,13 +3,13 @@ from statistics import mean, stdev, StatisticsError
 from typing import Any
 
 from interfaces.message_broker import Broker
-from interfaces.consumer import rabbitMQConsumer
+from interfaces.consumer import RabbitMQConsumer
 from commons.logger import logger
 from commons.configuration import Configuration
 from commons.broker import broker
 
 
-class Transformer(rabbitMQConsumer):
+class Transformer(RabbitMQConsumer):
 
     def _action(self, message: Any):
         message = json.loads(message)


### PR DESCRIPTION
- [x] `src/models` where data models are defined, e.g. SQL based on SQLAlchemy
- [x] `src/server` implements a second WS endpoint for structured data whose values are automatically randomly generated from the SQL model specified
- [x] `src/loader` is an implementation of `RabbitMQConsumer` that store the message as it is in the DB
- [x] add a DBRMS, e.g. PostgreSQL


To test if working, other than containers' logs, query the DB as follows:
```
docker exec -it deploy-postgres-DB-1 psql -U postgres -h localhost -p 5432 -d pastiposte -c "select * from structured_data;"
```